### PR TITLE
add draft software requirements for wallet backup, add skeleton design document

### DIFF
--- a/design.md
+++ b/design.md
@@ -1,0 +1,54 @@
+# Design for Minimum Viable Hard Fork - Bitcoin Unlimited edition
+
+##1. Contents <a id="1-contents"></a>
+
+1. [Contents](#1-contents)
+2. [Introduction](#2-introduction)
+3. [Overview of changes](#3-overview)
+4. [Architecture](#4-architecture)
+5. [Detailed design](#5-detailed-design)
+6. [Requirements traceability](#6-req-traceability)
+
+##2. Introduction <a id="2-introduction"></a>
+
+To be completed.
+
+Should give describe the purpose and structure of this document,
+its scope and intended audience, and give references to other applicable
+documents and reference material.
+
+##3. Overview of changes <a id="3-overview"></a>
+
+To be completed.
+
+##4. Architecture <a id="4-architecture"></a>
+
+To be completed.
+
+Should indicate parts of the system are being changed and how.
+
+##5. Detailed design <a id="5-detailed-design"></a>
+
+To be completed.
+
+Detailed design information on all the changes.
+Elements of the design need to be given unique identifiers, so that they
+can be traced back to requirements, and identified in the code.
+
+###5.x Wallet backup procedure
+
+(this is a temporary section to hold some preliminary ideas on this)
+
+Steps in wallet file backup procedure (tentative):
+  1. close the existing wallet disk file
+  2. attempt to open the backup wallet disk file for writing
+  3. copy the existing wallet file into the backup file
+  4. close the backup file
+  5. re-open the existing wallet file (to resume further operation)
+
+##6. Requirements traceability <a id="6-req-traceability"></a>
+
+To be completed.
+
+Requires the design elements (in Detailed Design) to be identifiable so
+that we can match them to requirements.

--- a/requirements.md
+++ b/requirements.md
@@ -537,9 +537,117 @@ Draft of Minimum Viable Hard Fork based on Bitcoin Unlimited
 
     Notes:          -
 
-    Traceability:   MVHF-BU-USER-REQ-10
+    Traceability:   MVHF-BU-USER-REQ-10, MVHF-BU-SW-REQ-10-1, MVHF-BU-SW-REQ-10-2,
+                    MVHF-BU-SW-REQ-10-3, MVHF-BU-SW-REQ-10-4, MVHF-BU-SW-REQ-10-5
 
 
 ##4. Software requirements <a id="4-sw-reqs"></a>
 
-To be completed.
+    Requirement:    MVHF-BU-SW-REQ-10-1
+
+    Origin:         BTCfork
+
+    Type:           Functional
+
+    Title:          CONFIGURATION PARAMETER FOR WALLET BACKUP FILE LOCATION
+
+    Text:           The client shall allow the user to configure a file path
+                    where the wallet backup file shall be created when the
+                    fork is triggered.
+
+    Rationale:      It should be the user's choice to decide where to create
+                    the wallet backup. For safety reasons no switch is
+                    provided to disable the wallet backup.
+
+    Notes:          If the specified configuration value does not includes
+                    path separators, it is to be treated as a filename and
+                    the default path where a user wallet is located shall
+                    be used.
+                    If the specified configuration value includes path
+                    separators, the backup shall be created at that
+                    specified location (path + filename).
+
+    Traceability:   MVHF-BU-SYS-REQ-10
+---
+    Requirement:    MVHF-BU-SW-REQ-10-2
+
+    Origin:         BTCfork
+
+    Type:           Functional
+
+    Title:          INITIATE WALLET BACKUP AFTER COMPLETION OF TRIGGER BLOCK PROCESSING
+
+    Text:           After processing the trigger block, the client shall
+                    initiate the wallet backup procedure.
+
+    Rationale:      The backup of the wallet can and should be done *after*
+                    the trigger block has been digested.
+
+    Notes:          This requirement needs to be verified by receiving some
+                    funds in the trigger block, and checking that they have
+                    been accounted for in the backed-up wallet.
+
+    Traceability:   MVHF-BU-SYS-REQ-10
+---
+    Requirement:    MVHF-BU-SW-REQ-10-3
+
+    Origin:         BTCfork
+
+    Type:           Functional
+
+    Title:          WALLET BACKUP PROCEDURE - IF RUNNING WITH A WALLET IN USE
+
+    Text:           If running with a wallet in use, the client shall back up
+                    the wallet, ensuring that the application cannot write
+                    to it while performing the backup.
+
+    Rationale:      If a client is running with a wallet then it should be backed up.
+                    If wallet use is disabled (e.g. using --disable-wallet),
+                    there is no need to backup a wallet - in that case
+                    MVHF-BU-SW-REQ-10-4 applies.
+
+    Notes:          -
+
+    Traceability:   MVHF-BU-SYS-REQ-10
+---
+    Requirement:    MVHF-BU-SW-REQ-10-4
+
+    Origin:         BTCfork
+
+    Type:           Functional
+
+    Title:          WALLET BACKUP PROCEDURE - IF RUNNING WITHOUT A WALLET
+
+    Text:           If running without a wallet, the client shall skip the
+                    wallet backup procedure.
+
+    Rationale:      If a client is not running with a wallet (e.g. using
+                    --disable-wallet), there is no need nor safe ability
+                    to perform the backup.
+
+    Notes:          There is no need to back up a wallet if none is in active
+                    use. In this case the user assumes responsibility for
+                    backing up any existing wallet files prior to using them
+                    with the client.
+
+    Traceability:   MVHF-BU-SYS-REQ-10
+---
+    Requirement:    MVHF-BU-SW-REQ-10-5
+
+    Origin:         BTCfork
+
+    Type:           Functional
+
+    Title:          SAFE CLIENT SHUTDOWN IN CASE OF WALLET BACKUP FAILURE
+
+    Text:           If the wallet backup procedure (refer to
+                    MVHF-BU-SW-REQ-10-3) fails, the client shall perform a
+                    safe shutdown which preserves the state of the wallet
+                    prior to the fork.
+
+    Rationale:      Do not risk writing post-fork data to the wallet.
+
+    Notes:          -
+
+    Traceability:   MVHF-BU-SYS-REQ-10
+


### PR DESCRIPTION
Added first software requirements:
- wallet backup (tracing to SYS-REQ-10), because wallet backup is easy to specify/design and implement/test largely independently from the other changes, and someone's wanting to implement it already, so I decided to deepen the spec there first.

Started to structure the design document a little.
