### PR TITLE
update SegWit triggering after Core merge of deployment parameters for BIP141/143/147

### DIFF
--- a/design.md
+++ b/design.md
@@ -217,9 +217,12 @@ The TRIG-related parameters to be placed into the common files:
 BIP9 deployment parameters for SegWit soft-fork activation will be added in
 params.h / chainparams.cpp .
 
-The precise values are still incompletely specified by Bitcoin Core's BIP141
-(at the time of writing, the mainnet start time is listed as "TBD" in
-https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#Deployment).
+SegWit (BIP141/143/147) deployment parameters have been set as follows:
+(https://github.com/bitcoin/bitcoin/pull/8937)
+
+- versionbit 1
+- start time: midnight 15 november 2016 UTC (Epoch timestamp 1479168000)
+- timeout: midnight 15 november 2017 UTC (Epoch timestamp 1510704000)
 
 
 ####5.1.3 New consensus parameters for fixed trigger height (MVHF-BU-DES-TRIG-3)

--- a/requirements.md
+++ b/requirements.md
@@ -57,7 +57,7 @@ Draft of Minimum Viable Hard Fork based on Bitcoin Unlimited
                     A Unlimited-derived MVHF implementation including the additional
                     SegWit trigger would not need the main SegWit functionality,
                     only the BIP9 activation logic and parameters compatible with
-                    BIP141 deployment.
+                    BIP141/143/147 deployment.
                     2. Once SegWit is released, the final code needs to be
                     inspected to ensure that Core's implementation conforms
                     to BIP9 in the sense that the 95% threshold is respected
@@ -697,9 +697,11 @@ Draft of Minimum Viable Hard Fork based on Bitcoin Unlimited
 
     Rationale:      This fulfils the SegWit part of the system requirement.
 
-    Notes:          SegWit (BIP141) deployment parameters are not entirely
-                    finalized.
-                    They may need to be approximated for test purposes.
+    Notes:          SegWit (BIP141/143/147) deployment parameters have been set in
+                    https://github.com/bitcoin/bitcoin/pull/8937
+                    The source code release accompanying the official 0.13.1
+                    release should be examined for any deviations from the
+                    assumed BIP9 activation strategy.
 
     Traceability:   MVHF-BU-SYS-REQ-2
 ---


### PR DESCRIPTION
Core has merged SegWit deployment paramers: https://github.com/bitcoin/bitcoin/pull/8937

For now, it looks like BIP9 will be followed (95% activation threshold). To be verified once Bitcoin Core 0.13.1 is released.
