### PR TITLE
merge work related to keeping track of fork activation state (aligned with MVF-BU)

### DIFF
--- a/design.md
+++ b/design.md
@@ -241,17 +241,56 @@ The active fork height value will be stored in a global variable
 (FinalActivateForkHeight) accessible from various parts of the code.
 
 
-####5.1.5 New global variable for fork trigger state (MVHF-CORE-DES-TRIG-5)
+####5.1.5 New variables and config file for tracking fork activation states
+
+#####5.1.5.1 New global variables (MVHF-CORE-DES-TRIG-5)
 
 A new boolean global variable, isMVFHardForkActive, will be added to
-track the activation state of the fork.
+track the present activation state of the fork's new consensus rules.
 It will be initialized to false and set to true when the block height of
-the active chain is at least equal to `FinalActivateForkHeight`.
+the active chain is at least equal to `FinalActivateForkHeight` or when
+the SegWit soft-fork activates.
 When the variable transitions to true, fork activation actions will be
 performed.
 If a re-org happens and the height of the active chain drops below the
 `FinalActivateForkHeight`, fork deactivation actions will be performed
 (i.e. reversion to pre-fork consensus rules).
+
+Another new boolean global variable, wasMVFHardForkPreviouslyActivated,
+will be added for tracking the activation state of the fork across
+program restarts.
+It will be initialized to false and set to true only if a btcfork.conf
+configuration file is found at startup (ref TODO).
+If this variable is set to true, certain one-off fork activation actions
+(e.g. network separation and the automatic wallet backup) will be skipped.
+
+
+#####5.1.5.2 btcfork.conf configuration file (MVHF-CORE-DES-TRIG-10)
+
+Certain forking actions, such as separating to a different network,
+should be performed only once and persisted across restarts of the
+client.
+
+The software will not modify the user's existing configuration file
+(bitcoin.conf) automatically as that would be too risky (some users
+re-use the same configuration file for several clients).
+
+Instead, when the fork activates, the client will write out fork-relevant
+configuration items into a separate configuration file (btcfork.conf) in
+the datadir.
+
+If this file is present during startup, the client software will know
+that the fork has been activated already.
+
+Primarily, this will be used to connect to the new (forked) network instead
+of the old network.
+
+The software shall also warn the user at startup that certain fork
+configuration parameters can be integrated (manually) into the existing
+configuration file (bitcoin.conf), whereupon the btcfork.conf file may
+be removed (since the node is past the fork activation point, another fork
+activation will not be performed unless non-default fork parameters are
+specified by the user via command line or the configuration file.
 
 
 ####5.1.6 Fork activation procedure (MVHF-CORE-DES-TRIG-6)
@@ -564,6 +603,7 @@ MVHF-CORE-SW-REQ-2-1 | MVHF-CORE-DES-TRIG-3,MVHF-CORE-DES-TRIG-4,MVHF-CORE-DES-T
 MVHF-CORE-SW-REQ-2-2 | MVHF-CORE-DES-TRIG-2,MVHF-CORE-DES-TRIG-6
 MVHF-CORE-SW-REQ-2-3 | MVHF-CORE-DES-TRIG-5
 MVHF-CORE-SW-REQ-2-4 | MVHF-CORE-DES-TRIG-9
+MVHF-CORE-SW-REQ-2-5  | MVHF-CORE-DES-TRIG-10
 MVHF-CORE-SW-REQ-10-1 | MVHF-CORE-DES-WABU-1,MVHF-CORE-DES-WABU-2
 MVHF-CORE-SW-REQ-10-2 | MVHF-CORE-DES-WABU-3
 MVHF-CORE-SW-REQ-10-3 | MVHF-CORE-DES-WABU-4
@@ -573,7 +613,6 @@ MVHF-CORE-SW-REQ-11-1 | MVHF-CORE-DES-IDME-1,MVHF-CORE-DES-IDME-2,MVHF-CORE-DES-
 MVHF-CORE-SW-REQ-11-2 | MVHF-CORE-DES-IDME-5
 TODO (software reqs) | MVHF-CORE-DES-NSEP-1
 TODO (software reqs) | MVHF-CORE-DES-DIAD-1
-TODO (software reqs) | MVHF-CORE-DES-CSIG-1
 
 
 ###6.2 Design -> requirements
@@ -598,6 +637,7 @@ MVHF-CORE-DES-TRIG-6 | MVHF-CORE-SW-REQ-2-1,MVHF-CORE-SW-REQ-2-2
 MVHF-CORE-DES-TRIG-7 | MVHF-CORE-SW-REQ-1-2
 MVHF-CORE-DES-TRIG-8 | MVHF-CORE-SW-REQ-1-3
 MVHF-CORE-DES-TRIG-9 | MVHF-CORE-SW-REQ-2-4
+MVHF-CORE-DES-TRIG-10| MVHF-CORE-SW-REQ-2-5
 MVHF-CORE-DES-WABU-1,MVHF-CORE-DES-WABU-2 | MVHF-CORE-SW-REQ-10-1
 MVHF-CORE-DES-WABU-3 | MVHF-CORE-SW-REQ-10-2
 MVHF-CORE-DES-WABU-4 | MVHF-CORE-SW-REQ-10-3,MVHF-CORE-SW-REQ-10-4

--- a/requirements.md
+++ b/requirements.md
@@ -351,7 +351,7 @@ Draft of Minimum Viable Hard Fork based on Bitcoin Core
                     the chains and enforce the updated consensus rules of the fork.
 
     Traceability:   MVHF-CORE-USER-REQ-2, MVHF-CORE-SW-REQ-2-1, MVHF-CORE-SW-REQ-2-2
-                    MVHF-CORE-SW-REQ-2-3, MVHF-CORE-SW-REQ-2-4
+                    MVHF-CORE-SW-REQ-2-3, MVHF-CORE-SW-REQ-2-4, MVHF-CORE-SW-REQ-2-5
 ---
     Requirement:    MVHF-CORE-SYS-REQ-3
 
@@ -646,11 +646,8 @@ Draft of Minimum Viable Hard Fork based on Bitcoin Core
 
     Rationale:      This fulfils the SegWit part of the system requirement.
 
-    Notes:          SegWit (BIP141/143/147) deployment parameters have been set in
-                    https://github.com/bitcoin/bitcoin/pull/8937
-                    The source code release accompanying the official 0.13.1
-                    release should be examined for any deviations from the
-                    assumed BIP9 activation strategy.
+    Notes:          SegWit (BIP141/143/147) deployment parameters have been
+                    set in https://github.com/bitcoin/bitcoin/pull/8937 .
 
     Traceability:   MVHF-CORE-SYS-REQ-2
 ---
@@ -692,7 +689,32 @@ Draft of Minimum Viable Hard Fork based on Bitcoin Core
 
     Notes:          -
 
-    Traceability:   MVHF-BU-SYS-REQ-2
+    Traceability:   MVHF-CORE-SYS-REQ-2
+---
+    Requirement:    MVHF-CORE-SW-REQ-2-5
+
+    Origin:         BTCfork
+
+    Type:           Functional
+
+    Title:          PERSIST FORK ACTIVATION STATE IN CONFIG FILE
+
+    Text:           The client shall create a special configuration file
+                    in the datadir to persist the knowledge that it has
+                    already activated the fork.
+
+    Rationale:      The fork activation leads to some irrevocable
+                    actions (e.g. separating onto a different network)
+                    that need to be persisted when the node is shut down
+                    and later restarted.
+                    At startup, if this special config file is present,
+                    the software can take appropriate measures to ensure
+                    that it correctly operates on the forked network
+                    and avoids the old network.
+
+    Notes:          -
+
+    Traceability:   MVHF-CORE-SYS-REQ-2
 ---
     Requirement:    MVHF-CORE-SW-REQ-10-1
 


### PR DESCRIPTION
merge work related to keeping track of fork activation state (aligned with MVF-BU):

- added MVHF-CORE-SW-REQ-2-5 (create config file to persis fork activation state)
- updated MVHF-CORE-DES-TRIG-5 (state vars: add wasMVFHardForkPreviouslyActivated)
- added MVHF-CORE-DES-TRIG-10 (btcfork.conf file)